### PR TITLE
Comment out printing every filename during unzip

### DIFF
--- a/src/elzip.cpp
+++ b/src/elzip.cpp
@@ -24,7 +24,7 @@ namespace elz
                     create_directory(fillPath);
                 }
             }
-            std::cout << "Opening file : " << filename << std::endl;
+            // std::cout << "Opening file : " << filename << std::endl;
             zipFile.openEntry(filename.c_str());
             std::ofstream wFile;
             wFile.open(cFile.string(), std::ios_base::binary | std::ios_base::out);


### PR DESCRIPTION
A very simple change, stop printing out every filename during unzipping, as it doesn't really make sense for a library to do so.