### PR TITLE
remove unnecessary zlib submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,8 +3,3 @@
 	url = https://github.com/zlib-ng/minizip-ng.git
 	ignore = dirty
 	shallow = true
-[submodule "extlibs/zlib"]
-	path = extlibs/zlib
-	url = https://github.com/madler/zlib.git
-	ignore = dirty
-	shallow = true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,13 +2,9 @@ cmake_minimum_required(VERSION 3.12)
 
 project(elzip)
 
-option(ELZIP_EXCLUDE_ZLIB "Use this to exclude internal zlib copy." OFF)
 option(ELZIP_EXCLUDE_MINIZIP "Use this to exclude internal minizip copy." OFF)
 option(ELZIP_TESTS "includes tests for 11Zip." OFF)
 
-if(NOT ELZIP_EXCLUDE_ZLIB)
-    add_subdirectory(extlibs/zlib EXCLUDE_FROM_ALL)
-endif()
 if(NOT ELZIP_EXCLUDE_MINIZIP)
     add_subdirectory(extlibs/minizip EXCLUDE_FROM_ALL)
 endif()
@@ -45,15 +41,6 @@ target_include_directories(elzip
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
-# NOTE(assertores): zlib renames the file zconf.h into zconf.h.included
-# because the file is generated in the build folder.
-# see https://github.com/madler/zlib/issues/133
-if(NOT ELZIP_EXCLUDE_ZLIB)
-target_include_directories(elzip
-    PUBLIC
-        ${CMAKE_CURRENT_BINARY_DIR}/extlibs/zlib
-)
-endif()
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)

--- a/src/zipper.cpp
+++ b/src/zipper.cpp
@@ -3,7 +3,6 @@
 #include <ctime>
 
 #include <minizip/mz_compat.h>
-#include <zlib/zlib.h>
 
 #include <zipper.hpp>
 
@@ -74,7 +73,7 @@ namespace ziputils
             zip_fileinfo zi = {0};
             getTime(zi.tmz_date);
 
-            int err = zipOpenNewFileInZip(zipFile_, filename, &zi, nullptr, 0, nullptr, 0, nullptr, Z_DEFLATED, Z_DEFAULT_COMPRESSION);
+            int err = zipOpenNewFileInZip(zipFile_, filename, &zi, nullptr, 0, nullptr, 0, nullptr, Z_DEFLATED, MZ_COMPRESS_LEVEL_DEFAULT);
 
             entryOpen_ = (err == ZIP_OK);
         }


### PR DESCRIPTION
Pretty self explanatory.
DISCLAIMER: I did not test this extensively, but as far as my google-foo goes, `Z_DEFAULT_COMPRESSION` and `MZ_COMPRESS_LEVEL_DEFAULT` are both defined as `-1`.