### PR TITLE
Fix mismatch between source and header for zipFolder

### DIFF
--- a/include/elzip/elzip.hpp
+++ b/include/elzip/elzip.hpp
@@ -20,5 +20,5 @@ namespace elz
 
     void extractZip(const path& archive, const path& target = ".");
     void extractFile(const path& archive, const path& fileInArchive, const path& target = ".", std::string outFilename = "");
-    void zipFolder(path folder, path archivePath = "");
+    void zipFolder(const path& folder, path archivePath = "");
 }


### PR DESCRIPTION
Due to a mismatch between the definition of `zipFolder` in `elzip.hpp` and `elzip.cpp` there are linker errors for Clang and GCC. This fixes those.