### PR TITLE
Fix: Sub directories are not zipped correctly

### DIFF
--- a/src/elzip.cpp
+++ b/src/elzip.cpp
@@ -83,6 +83,11 @@ namespace elz
         zipper.open(archive_path.string().c_str());
         for (const auto& path : std::filesystem::recursive_directory_iterator(directory))
         {
+            if (std::filesystem::is_directory(std::filesystem::status(path)))
+            {
+                continue;
+            }
+            
             const auto& absolute_path = path.path();
             auto relativePath = std::filesystem::relative(absolute_path, directory);
             zipper.addEntry(relativePath.string().c_str());


### PR DESCRIPTION
# Context

Unzip Libreoffice odt file works fine.  
Zipping again the directory to recreate the file result a corrupted file.

# Source of bug

File zipped are not the same as in original unzipped file. The directories are empty and, for some directory some files have been created with the same name

# Bug Fix

When recursing over directories, do not perform action on directory and only add files within directories

# Validation

I'm using this fix to handle odt files and it works properly. Note: No automated tests are proposed in the MR...