### PR TITLE
Decompress only mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@
 .vscode/
 .idea/
 build/
+*.user

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,19 +4,36 @@ project(elzip)
 
 option(ELZIP_EXCLUDE_MINIZIP "Use this to exclude internal minizip copy." OFF)
 option(ELZIP_TESTS "includes tests for 11Zip." OFF)
+option(ELZIP_DECOMPRESS_ONLY "Only support decompression" OFF)
 
 if(NOT ELZIP_EXCLUDE_MINIZIP)
     set(MZ_BZIP2 OFF)
     set(MZ_ICONV OFF)
     set(MZ_LZMA OFF)
-    set(MZ_PKCRYPT ON)
     set(MZ_SIGNING OFF)
-    set(MZ_WZAES ON)
     set(MZ_ZSTD OFF)
-    # Enabling ZLIB and MZ_COMPAT
     set(MZ_FETCH_LIBS ON)
-    set(MZ_ZLIB ON)
+    # Enabling MZ_COMPAT
     set(MZ_COMPAT ON)
+
+    if (ELZIP_DECOMPRESS_ONLY)
+        set(MZ_LIBCOMP OFF)
+        set(MZ_PKCRYPT OFF)
+        set(MZ_WZAES OFF)
+        set(MZ_OPENSSL OFF)
+        set(MZ_LIBBSD OFF)
+        set(MZ_ZLIB OFF)
+        set(MZ_PKCRYPT OFF)
+        set(MZ_WZAES OFF)
+
+        set(MZ_DECOMPRESS_ONLY ON)
+    else()
+        set(MZ_ZLIB ON)
+        set(MZ_PKCRYPT ON)
+        set(MZ_WZAES ON)
+
+    endif()
+
     add_subdirectory(extlibs/minizip EXCLUDE_FROM_ALL)
 endif()
 

--- a/include/elzip/elzip.hpp
+++ b/include/elzip/elzip.hpp
@@ -10,7 +10,7 @@ namespace elz
     class zip_exception : public std::runtime_error
     {
     public:
-        zip_exception(const std::string& error);
+        explicit zip_exception(const std::string& error);
         ~zip_exception() override = default;
     };
 
@@ -23,5 +23,5 @@ namespace elz
     void extractZip(const path& archive, const path& target = ".", const std::string& password = "");
     void extractFile(const path& archive, const path& fileInArchive, const path& target = ".", std::string outFilename = "", const std::string& password = "");
     void zipFolder(const path& folder, path archivePath = "");
-    void zipFiles(const std::vector<path>& files, path archivePath = "archive.zip");
+    void zipFiles(const std::vector<path>& files, const path& archivePath = "archive.zip");
 }  // namespace elz

--- a/include/elzip/unzipper.hpp
+++ b/include/elzip/unzipper.hpp
@@ -19,7 +19,7 @@ namespace ziputils
     {
     public:
         unzipper();
-        ~unzipper(void);
+        ~unzipper();
 
         bool open(std::string_view filename);
         void close();
@@ -27,14 +27,14 @@ namespace ziputils
 
         bool openEntry(std::string_view filename, std::string_view password = "");
         void closeEntry();
-        bool isOpenEntry() const;
-        unsigned int getEntrySize() const;
+        [[nodiscard]] bool isOpenEntry() const;
+        [[nodiscard]] unsigned int getEntrySize() const;
 
         const std::vector<std::string>& getFilenames();
         const std::vector<std::string>& getFolders();
 
         unzipper& operator>>( std::ostream& os );
-        std::string dump() const;
+        [[nodiscard]] std::string dump() const;
 
     private:
         void readEntries();

--- a/include/elzip/zipper.hpp
+++ b/include/elzip/zipper.hpp
@@ -12,15 +12,15 @@ namespace ziputils
     {
     public:
         zipper();
-        ~zipper(void);
+        ~zipper();
 
         bool open(const char* filename, bool append = false);
         void close();
-        bool isOpen() const;
+        [[nodiscard]] bool isOpen() const;
 
         bool addEntry(const char* filename);
         void closeEntry();
-        bool isOpenEntry() const;
+        [[nodiscard]] bool isOpenEntry() const;
 
         zipper& operator<<(std::istream& is);
 

--- a/src/elzip.cpp
+++ b/src/elzip.cpp
@@ -18,7 +18,7 @@ namespace elz
         {
             throw zip_exception("error on resolving path of entry : '" + entry + "'");
         }
-        return std::string(buf.data());
+        return buf.data();
     }
 
     void _extractFile(ziputils::unzipper& zipFile, const path& filename, const path& target, const std::string& password = "")
@@ -102,7 +102,7 @@ namespace elz
         zipper.close();
     }
 
-    void zipFiles(const std::vector<path>& files, path archivePath)
+    void zipFiles(const std::vector<path>& files, const path& archivePath)
     {
         ziputils::zipper zipper;
         zipper.open(archivePath.string().c_str());

--- a/src/unzipper.cpp
+++ b/src/unzipper.cpp
@@ -17,7 +17,7 @@ namespace ziputils
     }
 
     // Default destructor
-    unzipper::~unzipper(void)
+    unzipper::~unzipper()
     {
         close();
     }

--- a/src/zipper.cpp
+++ b/src/zipper.cpp
@@ -16,7 +16,7 @@ namespace ziputils
     }
 
     // Default destructor
-    zipper::~zipper(void)
+    zipper::~zipper()
     {
         close();
     }


### PR DESCRIPTION
Requires #20.
If we use decompress-only mode and call `elz::zipFiles` or `elz::zipFolder` it will produce a empty zip(not a invalid one)

Edit: Closes #19 