### PR TITLE
Leave MZ_ZLIB on it's default when using ELZIP_DECOMPRESS_ONLY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,13 +24,11 @@ if(NOT ELZIP_EXCLUDE_MINIZIP)
         set(MZ_WZAES OFF)
         set(MZ_OPENSSL OFF)
         set(MZ_LIBBSD OFF)
-        set(MZ_ZLIB OFF)
         set(MZ_PKCRYPT OFF)
         set(MZ_WZAES OFF)
 
         set(MZ_DECOMPRESS_ONLY ON)
     else()
-        set(MZ_ZLIB ON)
         set(MZ_PKCRYPT ON)
         set(MZ_WZAES ON)
 


### PR DESCRIPTION
Hi,

ELZIP_DECOMPRESS_ONLY was a great addition that really helps minimize dependencies.  However, we've encountered `dump error` exceptions from minizip when trying to elz::extractZip zip files when ELZIP_DECOMPRESS_ONLY is enabled.

This change prevents overriding of MZ_ZLIB within 11Zip so that zlib zip files can be decompressed if required. MZ_ZLIB can now be toggled on and off in client project's cmake configuration.

Thanks!