### PR TITLE
Fix container overflow

### DIFF
--- a/src/unzipper.cpp
+++ b/src/unzipper.cpp
@@ -178,7 +178,7 @@ namespace ziputils
         {
             unsigned int size = getEntrySize();
             std::vector<char> buf;
-            buf.reserve(size);
+            buf.resize(size);
             size = unzReadCurrentFile(zipFile_, buf.data(), size);
             if (size > 0)
             {
@@ -202,7 +202,7 @@ namespace ziputils
             std::string ret;
             if (size > 0)
             {
-                buf.reserve(size);
+                buf.resize(size);
                 size = unzReadCurrentFile(zipFile_, buf.data(), size);
 
                 if (size > 0)

--- a/src/unzipper.cpp
+++ b/src/unzipper.cpp
@@ -202,16 +202,15 @@ namespace ziputils
         if (isOpenEntry())
         {
             unsigned int size = getEntrySize();
-            std::vector<char> buf;
             std::string ret;
             if (size > 0)
             {
-                buf.resize(size);
-                int length = unzReadCurrentFile(zipFile_, buf.data(), size);
+                ret.resize(size);
+                int length = unzReadCurrentFile(zipFile_, ret.data(), size);
 
                 if (length >= 0)
                 {
-                    ret = std::string(buf.data(), length);
+                    ret.resize(length);
                 }
                 else
                 {

--- a/src/unzipper.cpp
+++ b/src/unzipper.cpp
@@ -179,11 +179,15 @@ namespace ziputils
             unsigned int size = getEntrySize();
             std::vector<char> buf;
             buf.resize(size);
-            size = unzReadCurrentFile(zipFile_, buf.data(), size);
-            if (size > 0)
+            int length = unzReadCurrentFile(zipFile_, buf.data(), size);
+            if (length >= 0)
             {
-                os.write(buf.data(), size);
+                os.write(buf.data(), length);
                 os.flush();
+            }
+            else
+            {
+                throw dump_error();
             }
         }
         else
@@ -203,11 +207,15 @@ namespace ziputils
             if (size > 0)
             {
                 buf.resize(size);
-                size = unzReadCurrentFile(zipFile_, buf.data(), size);
+                int length = unzReadCurrentFile(zipFile_, buf.data(), size);
 
-                if (size > 0)
+                if (length >= 0)
                 {
-                    ret = std::string(buf.data(), size);
+                    ret = std::string(buf.data(), length);
+                }
+                else
+                {
+                    throw dump_error();
                 }
             }
             return ret;


### PR DESCRIPTION
Hi,

0f26d58e75a8c563cc643aaa664c6c242235e75f was picked up by our sanitized builds due to writes outside of the bounds of a container. While fixing that it was also spotted that f332fd55134d9d0b9e4d1a3e97f61cf0aef3df99 could occur with corrupt data, though this was only an observation and no attempt was made to try and trigger the issue.

Note that while I can see logic in the `CMakeLists.txt` to support pre-C++17, `unzipper.cpp` uses `std::string_view` which wasn't added until C++17, in which case c767b9b375b9e9127c44a0f657f2105b71ff9d61 should be OK to use too. If it's not then I can drop that commit since it's not fixing anything.